### PR TITLE
[Feature Request] Possibility to give a global customContext object..

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can optionally change the level (default is ERROR) and remove the surroundin
 You can also optionally give some extra debug info by defining a global `window.customContext` in your page before calling the Nelmio error logger:
 
     <script>
-        window.customContext = { userinfo: 'some info', appinfo: 'another useful info' };
+        window.nelmio_js_logger_custom_context = { userinfo: 'some info', appinfo: 'another useful info' };
         {{ nelmio_js_error_logger('ERROR', false) }}
     </script>
 

--- a/TwigExtension.php
+++ b/TwigExtension.php
@@ -29,7 +29,7 @@ class TwigExtension extends \Twig_Extension
 (function () {
     var key,
         oldErrorHandler = window.onerror,
-        customContext = window.customContext || false,
+        customContext = window.nelmio_js_logger_custom_context,
         customContextStr = '';
 
     window.onerror = function(errorMsg, file, line) {
@@ -41,7 +41,7 @@ class TwigExtension extends \Twig_Extension
 
         if ('object' === typeof customContext) {
             for (key in customContext) {
-                customContextStr += '&context[' + key + ']=' + e(customContext[key]);
+                customContextStr += '&context[' + e(key) + ']=' + e(customContext[key]);
             }
         }
 
@@ -75,7 +75,7 @@ var $function = function(level, message, contextData) {
 
     if (contextData) {
         for (key in contextData) {
-            context += '&context[' + key + ']=' + e(contextData[key]);
+            context += '&context[' + e(key) + ']=' + e(contextData[key]);
         }
     }
     (new Image()).src = '$url?msg=' + e(message) + '&level=' + e(level) + context;


### PR DESCRIPTION
... to the default Nelmio onerror logger, without having to implement a custom behavior using the logger function.

Hi there, I'm using this awesome bundle, and the default behavior is just great for me. I quickly noticed that I would need some more extra info sent to the log when an error occurs. By chance, I have on my page an object with all this info I need. But I cannot automatically send it by implementing my own `onerror` function using your `log()` function.

That is the reason I have implemented the ability to define a global param allowing to give this extra info, with the basic implementation.

Hope the idea (an maybe not my current implementation) will be accepted :)

Best
