### PR TITLE
The "pattern" option is deprecated since version 2.2

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="nelmio_js_logger_log" pattern="/log">
+    <route id="nelmio_js_logger_log" path="/log">
         <default key="_controller">NelmioJsLoggerBundle:Log:create</default>
     </route>
 </routes>


### PR DESCRIPTION
With Symfony 2.7, it leads to "deprecation" alert