### PR TITLE
Switch the Twig integration to use non-deprecated APIs

### DIFF
--- a/TwigExtension.php
+++ b/TwigExtension.php
@@ -16,8 +16,8 @@ class TwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'nelmio_js_error_logger' => new \Twig_Function_Method($this, 'initErrorLogger', array('is_safe' => array('html', 'js'))),
-            'nelmio_js_logger' => new \Twig_Function_Method($this, 'initLogger', array('is_safe' => array('html', 'js'))),
+            new \Twig_SimpleFunction('nelmio_js_error_logger', array($this, 'initErrorLogger'), array('is_safe' => array('html', 'js'))),
+            new \Twig_SimpleFunction('nelmio_js_logger', array($this, 'initLogger'), array('is_safe' => array('html', 'js'))),
         );
     }
 


### PR DESCRIPTION
This makes the bundle compatible with Twig 2.0 and avoids the deprecation warning in 1.21+

This requires Twig 1.12+, but Symfony already has this min requirement on Twig since 2.3.0