### PR TITLE
add stacktrace.js to log full stacktraces

### DIFF
--- a/Controller/LogController.php
+++ b/Controller/LogController.php
@@ -10,9 +10,26 @@ class LogController extends Controller
 {
     public function createAction(Request $request)
     {
-        $level = $request->query->get('level');
-        $message = $request->query->get('msg');
-        $context = $request->query->get('context', array());
+        if("GET" == $request->getMethod()){
+            $level = (string) $request->query->get('level');
+            $message = (string) $request->query->get('msg');
+            $context = (array) $request->query->get('context', array());
+
+        } else {
+            $postData = json_decode($request->getContent());
+            $level = (string) $postData->level;
+            $message = (string) $postData->msg;
+            $context = (array) $postData->context;
+            $stacktrace = "";
+            foreach ($postData->stack as $stackframe) {
+                $fileName = property_exists($stackframe, 'fileName') ? $stackframe->fileName : "-";
+                $lineNumber = property_exists($stackframe, 'lineNumber') ? $stackframe->lineNumber : "-";
+                $function = property_exists($stackframe, 'functionName') ? $stackframe->functionName : "-";
+                $columnNumber = property_exists($stackframe, 'columnNumber') ? $stackframe->columnNumber : "-";
+                $stacktrace .= "\n$fileName : $function : $lineNumber : $columnNumber";
+            }
+            $context['stacktrace'] = $stacktrace;
+        }
 
         if ($this->get('nelmio_js_logger.logger')->write($level, $message, $context)) {
             return new Response(base64_decode('R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs'), 201, array('Content-Type' => 'image/gif'));

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Import the bundle's routing definition in `app/config/routing.yml`:
         resource: "@NelmioJsLoggerBundle/Resources/config/routing.xml"
         prefix:   /nelmio-js-logger
 
+### Optional: Log the whole javascript stack trace with Stacktrace.js
+[Stacktrace.js](http://www.stacktracejs.com/) is a small js-library to create javascript stack traces anywhere. You can load it by adding the following to your html template.
+`
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stacktrace.js/1.0.0/stacktrace.min.js" crossorigin></script>
+`
+If stacktrace.js is loaded before an error occurs, an array with stack trace information (file, line, column) will be logged additionally to the other information.
+
 ## Automated Error Logging ##
 
 The bundle exposes two twig functions that you should put in your site


### PR DESCRIPTION
Hi,

In my fork, I added support for logging the full js stack trace with stacktracejs (www.stacktracejs.com) when an error occurs (see this PR).

The code is not yet polished or unit-tested, but I wanted to know if you consider this a nice idea and intend to merge the feature into your branch once polished/tested or if you prefer the keep this bundle as slim as it is.

ToDo before merge:
- add nice way to load the stacktrace.min.js 
- add unit-test
- check & document browser-support
- add documentation
- add stacktrace support to 'init_logger'

Looking forward to your feedback.

Cheers,
dominik
