### PR TITLE
Support for Symfony 3

### DIFF
--- a/Logger.php
+++ b/Logger.php
@@ -2,7 +2,7 @@
 
 namespace Nelmio\JsLoggerBundle;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 class Logger
 {


### PR DESCRIPTION
Fix for Catchable Fatal Error: Argument 1 passed to Nelmio\JsLoggerBundle\Logger::__construct() must be an instance of Symfony\Component\HttpKernel\Log\LoggerInterface, instance of Symfony\Bridge\Monolog\Logger given

In Symfony 3.0 Symfony\Bridge\Monolog\Logger doesn't implement Symfony\Component\HttpKernel\Log\LoggerInterface anymore.