### PR TITLE
Upgrade to SF3.4

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('The level %s is not supported. Please choose one of '.json_encode($levels))
                         ->end()
                     ->end()
+                    ->requiresAtLeastOneElement()
                 ->end()
                 ->arrayNode('ignore_messages')
                     ->defaultValue(array())

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,7 +35,6 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('The level %s is not supported. Please choose one of '.json_encode($levels))
                         ->end()
                     ->end()
-                    ->cannotBeEmpty()
                 ->end()
                 ->arrayNode('ignore_messages')
                     ->defaultValue(array())


### PR DESCRIPTION
Remove this warning:

Using Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition::cannotBeEmpty() at path "nelmio_js_logger.allowed_levels" has no effect, consider requiresAtLeastOneElement() instead. In 4.0 both methods will behave the same.