### PR TITLE
Resolve and reject the Promise to avoid infinite loop

### DIFF
--- a/TwigExtension.php
+++ b/TwigExtension.php
@@ -41,11 +41,11 @@ var stackTraceJsModule = (function (basicModule) {
             function(stackframes) {
                 var req = new XMLHttpRequest();
                     req.onerror = function(err) {
-                                        if (typeof console !== 'undefined' && typeof console.log === 'function') {
-                                            console.log('An error occurred while trying to log an error using stacktrace.js!');
-                                        }
-                                        throw new Error('POST to $url failed.');
-                                   };
+                        if (typeof console !== 'undefined' && typeof console.log === 'function') {
+                            console.log('An error occurred while trying to log an error using stacktrace.js!');
+                        }
+                        basicModule.callSimpleLogger(errorMsg, file, line, col, error);
+                    };
                     req.onreadystatechange = function onreadystatechange() {
                         if (req.readyState === 4) {
                             if (req.status >= 200 && req.status < 400) {
@@ -56,7 +56,7 @@ var stackTraceJsModule = (function (basicModule) {
                                 if (typeof console !== 'undefined' && typeof console.log === 'function') {
                                     console.log('POST to $url failed with status: ' + req.status);
                                 }
-                                throw new Error('POST to $url failed with status: ' + req.status);
+                                basicModule.callSimpleLogger(errorMsg, file, line, col, error);
                             }
                         }
                     };


### PR DESCRIPTION
I noticed some huge traffic pikes on a client website and looked into it, it was all on the `nelmio_js_logger_log` route with 150x more requests than any other routes.

Looking at the access logs it was clear those requests all came from a single client, a single browser. 

That's because there is an infinite loop inside the logger. When the XHR try to send logs to the backend, if there is an error, a **throw new Error** is used. But that's done in a callback from within a Promise, and it will not reject the promise or be catched by the "catch" method. So the Error pop's up to the **window.onerror** event listener, and send data via XHR, which can fail again and throw a new Error, which will not be catched, etc etc.

I have no idea why the XHR is throwing an Error but I still have hits & logs on my backend... But anyway, here is a proposal to fix this: returning a Promise allow asynchronous function to reject or resolve it the proper way.

The only thing I'm not sure is browser support of Promise but StackTrace.js use Promise everywhere so maybe that's not an issue?

[Easier to read diff](https://github.com/nelmio/NelmioJsLoggerBundle/pull/21/files?w=1).