### PR TITLE
Mark the logger service as public explicitly

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,7 +10,7 @@
     </parameters>
 
     <services>
-        <service id="nelmio_js_logger.logger" class="%nelmio_js_logger.logger.class%">
+        <service id="nelmio_js_logger.logger" class="%nelmio_js_logger.logger.class%" public="true">
             <argument type="service" id="logger" />
             <argument>%nelmio_js_logger.allowed_levels%</argument>
             <argument>%nelmio_js_logger.ignore_messages%</argument>


### PR DESCRIPTION
The controller access this service dynamically, so it requires the service to be public. Symfony 3.4 makes services private by default.

An alternative would be to define the controller as a service instead.