### PR TITLE
Log the error column when using the basic logger

### DIFF
--- a/TwigExtension.php
+++ b/TwigExtension.php
@@ -154,6 +154,7 @@ var basicModule = (function () {
         '&level=$level' +
         '&context[file]=' + e(file) +
         '&context[line]=' + e(line) +
+        '&context[column]=' + e(col) +
         '&context[browser]=' + e(navigator.userAgent) +
         '&context[page]=' + e(document.location.href) + basic.fetchCustomContext();
     };


### PR DESCRIPTION
Lines are generally very long in JS files produced by bundlers (as minifiers remove newlines to reduce the size). So getting only the line number without the column number makes it much harder to identify the location of the error.