### PR TITLE
allowed Symfony 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         "php": ">=7",
         "ext-json": "*",
         "psr/log": "^1.0",
-        "symfony/config": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
-        "symfony/http-foundation": "^3.4 || ^4.2",
-        "symfony/http-kernel": "^3.4 || ^4.2",
-        "symfony/framework-bundle": "^3.4 || ^4.2"
+        "symfony/config": "^3.4 || ^4.2 || ^5.0",
+        "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
+        "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.2 || ^5.0",
+        "symfony/framework-bundle": "^3.4 || ^4.2 || ^5.0"
     },
     "require-dev": {
         "twig/twig": "^1.40 || ^2.10"


### PR DESCRIPTION
Just an update of composer.json to allow install on Symfony5
Test with Symfony 5.0.4 and no deprecated message in log