### PR TITLE
Fix the controller reference in the route

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -5,6 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="nelmio_js_logger_log" path="/log">
-        <default key="_controller">NelmioJsLoggerBundle:Log:create</default>
+        <default key="_controller">Nelmio\JsLoggerBundle\Controller\LogController::createAction</default>
     </route>
 </routes>


### PR DESCRIPTION
The callable should be referenced using the PHP notation rather than the bundle convention, as it is deprecated.

This change can be done directly, because 3.4 (which is the min version) supports that notation already.