### PR TITLE
Fix compat with XML config files

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
         $levelsCI = array_merge($levels, array_map('strtolower', $levels));
 
         $rootNode
+            ->fixXmlConfig('allowed_level')
             ->fixXmlConfig('ignore_message')
             ->fixXmlConfig('ignore_url_prefix', 'ignore_url_prefixes')
             ->children()


### PR DESCRIPTION
The configuration contains 3 prototyped array nodes, but only 2 of them were made compatible with XML.