### PR TITLE
Added @return annotation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -9,11 +9,13 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * This is the class that validates and merges configuration from your app/config files
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ *
+ * @final
  */
 class Configuration implements ConfigurationInterface
 {
     /**
-     * {@inheritDoc}
+     * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
     {

--- a/TwigExtension.php
+++ b/TwigExtension.php
@@ -6,6 +6,9 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+/**
+ * @final
+ */
 class TwigExtension extends AbstractExtension
 {
     private $router;
@@ -18,6 +21,9 @@ class TwigExtension extends AbstractExtension
         $this->stackTracePath = $stackTracePath;
     }
 
+    /**
+     * @return array
+     */
     public function getFunctions()
     {
         return array(

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         "php": ">=7",
         "ext-json": "*",
         "psr/log": "^1.0",
-        "symfony/config": "^3.4 || ^4.2 || ^5.0",
-        "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
-        "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0",
-        "symfony/http-kernel": "^3.4 || ^4.2 || ^5.0",
-        "symfony/routing": "^3.4 || ^4.2 || ^5.0"
+        "symfony/config": "^4.4 || ^5.3 || ^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0",
+        "symfony/http-foundation": "^4.4 || ^5.3 || ^6.0",
+        "symfony/http-kernel": "^4.4 || ^5.3 || ^6.0",
+        "symfony/routing": "^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {
         "twig/twig": "^1.40 || ^2.10"


### PR DESCRIPTION
Fixes these deprecation notices:

> Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "Nelmio\JsLoggerBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.

> User Deprecated: Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Nelmio\JsLoggerBundle\TwigExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
