### PR TITLE
Parameter handling

### DIFF
--- a/Controller/LogController.php
+++ b/Controller/LogController.php
@@ -18,10 +18,10 @@ class LogController
     public function createAction(Request $request)
     {
         if(Request::METHOD_GET === $request->getMethod()){
-            $level = (string) $request->query->get('level');
-            $message = (string) $request->query->get('msg');
-            $context = (array) $request->query->get('context', array());
-
+            $parameters = $request->query->all();
+            $level = $parameters['level'] ?? '';
+            $message = $parameters['msg'] ?? '';
+            $context = $parameters['context'] ?? [];
         } else {
             $postData = json_decode($request->getContent());
             $level = (string) $postData->level;


### PR DESCRIPTION
As described in #44, retrieving non-string values from the `InputBag` via `get()` is deprecated since Symfony 5.1 and throwns an exception since Symfony 6. There is already a pull-request for this, but it's a bit stalled so I openend a new one with the same fix incorporating the review from @stof. I hope that's ok.