### PR TITLE
Fix deprecations of Symfony 6.3

### DIFF
--- a/DependencyInjection/NelmioJsLoggerExtension.php
+++ b/DependencyInjection/NelmioJsLoggerExtension.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\Loader;
 class NelmioJsLoggerExtension extends Extension
 {
     /**
-     * {@inheritDoc}
+     * @return void
      */
     public function load(array $configs, ContainerBuilder $container)
     {


### PR DESCRIPTION
This uses `@return` to opt-out of the deprecation for now, as done for existing ones of older versions.

The bundle will likely require a new major version adding native types before being able to support Symfony 7.0