### PR TITLE
Add support for Symfony 7

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -14,19 +14,11 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    /**
-     * @return TreeBuilder
-     */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('nelmio_js_logger');
 
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $rootNode = $treeBuilder->root('nelmio_js_logger');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $levels = array('DEBUG', 'INFO', 'NOTICE', 'WARNING', 'ERROR', 'CRITICAL', 'ALERT', 'EMERGENCY');
         $levelsCI = array_merge($levels, array_map('strtolower', $levels));

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
         }
     ],
     "require": {
-        "php": ">=7",
+        "php": ">=7.2.5",
         "ext-json": "*",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/config": "^4.4 || ^5.3 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0",
-        "symfony/http-foundation": "^4.4 || ^5.3 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.3 || ^6.0",
-        "symfony/routing": "^4.4 || ^5.3 || ^6.0"
+        "symfony/config": "^4.4 || ^5.3 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0 || ^7.0",
+        "symfony/http-foundation": "^4.4 || ^5.3 || ^6.0 || ^7.0",
+        "symfony/http-kernel": "^4.4 || ^5.3 || ^6.0 || ^7.0",
+        "symfony/routing": "^4.4 || ^5.3 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "twig/twig": "^1.40 || ^2.10"
+        "twig/twig": "^1.40 || ^2.10 || ^3.0"
     },
     "autoload": {
         "psr-4": { "Nelmio\\JsLoggerBundle\\": "" }


### PR DESCRIPTION
This bumps the min PHP version to 7.2 because Symfony 7 requires adding a return type and this requires support for variance rules to stay compatible with older Symfony versions, which are available only in PHP 7.2+.