### PR TITLE
Fix the branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }


### PR DESCRIPTION
The master branch is not 1.5.x-dev anymore as several newer minor versions have been released since then.

To avoid having to remember updating it at each release, I used `1.x-dev` as branch alias so that it won't need an update until a new major version is done.