### PR TITLE
Update the documentation to import the PHP routing file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Import the bundle's routing definition in `app/config/routing.yml`:
 
     # app/config/routing.yml
     NelmioJsLoggerBundle:
-        resource: "@NelmioJsLoggerBundle/Resources/config/routing.xml"
+        resource: "@NelmioJsLoggerBundle/Resources/config/routing.php"
         prefix:   /nelmio-js-logger
 
 ## Automated Error Logging ##


### PR DESCRIPTION
XML routing files are deprecated in Symfony 7.4 and unsupported in 8.0.

#53 has added a PHP routing file (keeping the XML file for BC reasons) but forgot to update the documentation to use the PHP file